### PR TITLE
Fix MSVC compiling issue with constexprc opcopy assignment

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -1,4 +1,3 @@
-
 /*
 This is an implementation of std::span from P0122R7
 http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
@@ -391,7 +390,7 @@ public:
 
     ~span() noexcept = default;
 
-    TCB_SPAN_CONSTEXPR14 span& operator=(const span& other) noexcept = default;
+    span& operator=(const span& other) noexcept = default;
 
     // [span.sub], span subviews
     template <std::ptrdiff_t Count>


### PR DESCRIPTION
I stumbled upon this issue with our Appveyor test suite using 

```
-- The C compiler identification is MSVC 19.0.24241.7
-- The CXX compiler identification is MSVC 19.0.24241.7
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- xtl v0.4.16
-- Forcing tests build type to Release
-- Found GTest: C:/xtl-conda/Library/lib/gtest-md.lib  
-- Found Threads: TRUE  
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring done
-- Generating done
-- Build files have been written to: C:/projects/xtl
nmake test_xtl
Microsoft (R) Program Maintenance Utility Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.
Scanning dependencies of target test_xtl
[  6%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xbase64.cpp.obj
test_xbase64.cpp
[ 12%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xbasic_fixed_string.cpp.obj
test_xbasic_fixed_string.cpp
[ 18%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xcomplex.cpp.obj
test_xcomplex.cpp
[ 25%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xcomplex_sequence.cpp.obj
test_xcomplex_sequence.cpp
[ 31%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xclosure.cpp.obj
test_xclosure.cpp
[ 37%] Building CXX object test/CMakeFiles/test_xtl.dir/test_xdynamic_bitset.cpp.obj
test_xdynamic_bitset.cpp
c:\projects\xtl\include\xtl\xspan_impl.hpp(396): warning C4814: 'tcb::span<T,S>::operator =': in C++14 'constexpr' will not imply 'const'; consider explicitly specifying 'const'
c:\projects\xtl\include\xtl\xspan_impl.hpp(547): note: see reference to class template instantiation 'tcb::span<T,S>' being compiled
c:\projects\xtl\include\xtl\xspan_impl.hpp(396): error C2610: 'tcb::span<T,S> &tcb::span<T,S>::operator =(const tcb::span<T,S> &) noexcept const': is not a special member function which can be defaulted
c:\projects\xtl\include\xtl\xspan_impl.hpp(396): note: unexpected CV-qualifier
c:\projects\xtl\include\xtl\xspan_impl.hpp(396): warning C4814: 'tcb::span<std::X,-1>::operator =': in C++14 'constexpr' will not imply 'const'; consider explicitly specifying 'const'
        with
        [
            X=std::size_t
        ]
C:\projects\xtl\include\xtl/xdynamic_bitset.hpp(245): note: see reference to class template instantiation 'tcb::span<std::X,-1>' being compiled
        with
        [
            X=std::size_t
        ]
C:\projects\xtl\include\xtl/xdynamic_bitset.hpp(72): note: see reference to class template instantiation 'xtl::xdynamic_bitset_traits<B>' being compiled
        with
        [
            B=xtl::xdynamic_bitset_view<std::size_t>
        ]
C:\projects\xtl\include\xtl/xdynamic_bitset.hpp(199): note: see reference to class template instantiation 'xtl::xdynamic_bitset_base<xtl::xdynamic_bitset_view<std::size_t>>' being compiled
C:\projects\xtl\test\test_xdynamic_bitset.cpp(495): note: see reference to class template instantiation 'xtl::xdynamic_bitset_view<std::size_t>' being compiled
```