### PR TITLE
Fix for ability to move to user-defined namespace

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -754,13 +754,13 @@ constexpr auto get(span<E, S> s) -> decltype(s[N])
 namespace std {
 
 template <typename E, ptrdiff_t S>
-class tuple_size<tcb::span<E, S>> : public integral_constant<size_t, S> {};
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<E, S>> : public integral_constant<size_t, S> {};
 
 template <typename E>
-class tuple_size<tcb::span<E, tcb::dynamic_extent>>; // not defined
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<E, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
 
 template <size_t N, typename E, ptrdiff_t S>
-class tuple_element<N, tcb::span<E, S>> {
+class tuple_element<N, TCB_SPAN_NAMESPACE_NAME::span<E, S>> {
 public:
     using type = E;
 };


### PR DESCRIPTION
I suppose it's designed to allow moving to another namespace
by #define TCB_SPAN_NAMESPACE_NAME before include,
but it was broken on specialization of std:: traits