### PR TITLE
Class / struct mismatch warning issued by clang fixed

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -754,13 +754,13 @@ constexpr auto get(span<E, S> s) -> decltype(s[N])
 namespace std {
 
 template <typename E, ptrdiff_t S>
-class tuple_size<tcb::span<E, S>> : public integral_constant<size_t, S> {};
+struct tuple_size<tcb::span<E, S>> : public integral_constant<size_t, S> {};
 
 template <typename E>
-class tuple_size<tcb::span<E, tcb::dynamic_extent>>; // not defined
+struct tuple_size<tcb::span<E, tcb::dynamic_extent>>; // not defined
 
 template <size_t N, typename E, ptrdiff_t S>
-class tuple_element<N, tcb::span<E, S>> {
+struct tuple_element<N, tcb::span<E, S>> {
 public:
     using type = E;
 };


### PR DESCRIPTION
Fix for the class / struct mismatch warning issued by clang:

```
[…]/span/include/tcb/span.hpp:757:1: warning: 'tuple_size' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]
class tuple_size<tcb::span<E, S>> : public integral_constant<size_t, S> {};
^
```
