### PR TITLE
Compile time reduction and cmake test support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/tcb/span.hpp)
 target_include_directories(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(span INTERFACE cxx_std_11)
 
+enable_testing()
 add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,12 +14,14 @@ add_library(test_main catch_main.cpp)
 add_executable(test_span11
     test_span.cpp
 )
+add_test(span11 test_span11)
 target_link_libraries(test_span11 PUBLIC test_main span)
 target_compile_features(test_span11 PUBLIC cxx_std_11)
 
 add_executable(test_span14
     test_span.cpp
 )
+add_test(span14 test_span14)
 target_link_libraries(test_span14 PUBLIC test_main span)
 target_compile_features(test_span14 PUBLIC cxx_std_14)
 
@@ -28,10 +30,12 @@ add_executable(test_span17
     test_deduction_guides.cpp
     test_structured_bindings.cpp
 )
+add_test(span17 test_span17)
 target_link_libraries(test_span17 PUBLIC test_main span)
 target_compile_features(test_span17 PUBLIC cxx_std_17)
 
 add_executable(test_contract_checking
     test_contract_checking.cpp
 )
+add_test(contractchecking test_contract_checking)
 target_link_libraries(test_contract_checking PUBLIC test_main span)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,31 +9,29 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS Off)
 
+add_library(test_main catch_main.cpp)
+
 add_executable(test_span11
-    catch_main.cpp
     test_span.cpp
 )
-target_link_libraries(test_span11 PUBLIC span)
+target_link_libraries(test_span11 PUBLIC test_main span)
 target_compile_features(test_span11 PUBLIC cxx_std_11)
 
 add_executable(test_span14
-    catch_main.cpp
     test_span.cpp
 )
-target_link_libraries(test_span14 PUBLIC span)
+target_link_libraries(test_span14 PUBLIC test_main span)
 target_compile_features(test_span14 PUBLIC cxx_std_14)
 
 add_executable(test_span17
-    catch_main.cpp
     test_span.cpp
     test_deduction_guides.cpp
     test_structured_bindings.cpp
 )
-target_link_libraries(test_span17 PUBLIC span)
+target_link_libraries(test_span17 PUBLIC test_main span)
 target_compile_features(test_span17 PUBLIC cxx_std_17)
 
 add_executable(test_contract_checking
-    catch_main.cpp
     test_contract_checking.cpp
 )
-target_link_libraries(test_contract_checking PUBLIC span)
+target_link_libraries(test_contract_checking PUBLIC test_main span)


### PR DESCRIPTION
Notable compile time reduction of the tests by compiling the expensive test main only once.

Improved test handling and CTest support.