### PR TITLE
Simplify CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(span LANGUAGES CXX)
 
+enable_testing()
+
 add_library(span INTERFACE)
 target_sources(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/tcb/span.hpp)
 target_include_directories(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,6 @@ target_sources(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/tcb/span.hpp)
 target_include_directories(span INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(span INTERFACE cxx_std_11)
 
+set(TCB_SPAN_TEST_CXX_STD 11 CACHE STRING "C++ standard version for testing")
+
 add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,9 +25,11 @@ add_executable(test_span ${TEST_FILES})
 target_link_libraries(test_span PUBLIC span catch_main)
 set_target_properties(test_span PROPERTIES
                       CXX_STANDARD ${TCB_SPAN_TEST_CXX_STD})
+add_test(test_span test_span)
 
 add_executable(test_span_contract_checking
                test_contract_checking.cpp)
 target_link_libraries(test_span_contract_checking PUBLIC span catch_main)
 set_target_properties(test_span_contract_checking PROPERTIES
     CXX_STANDARD ${TCB_SPAN_TEST_CXX_STD})
+add_test(test_contract_checking test_span_contract_checking)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,31 +9,25 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS Off)
 
-add_executable(test_span11
-    catch_main.cpp
+add_library(catch_main catch_main.cpp)
+
+set(TEST_FILES
     test_span.cpp
 )
-target_link_libraries(test_span11 PUBLIC span)
-target_compile_features(test_span11 PUBLIC cxx_std_11)
 
-add_executable(test_span14
-    catch_main.cpp
-    test_span.cpp
-)
-target_link_libraries(test_span14 PUBLIC span)
-target_compile_features(test_span14 PUBLIC cxx_std_14)
+if (${TCB_SPAN_TEST_CXX_STD} GREATER_EQUAL 17)
+    list(APPEND TEST_FILES
+         test_deduction_guides.cpp
+         test_structured_bindings.cpp)
+endif()
 
-add_executable(test_span17
-    catch_main.cpp
-    test_span.cpp
-    test_deduction_guides.cpp
-    test_structured_bindings.cpp
-)
-target_link_libraries(test_span17 PUBLIC span)
-target_compile_features(test_span17 PUBLIC cxx_std_17)
+add_executable(test_span ${TEST_FILES})
+target_link_libraries(test_span PUBLIC span catch_main)
+set_target_properties(test_span PROPERTIES
+                      CXX_STANDARD ${TCB_SPAN_TEST_CXX_STD})
 
-add_executable(test_contract_checking
-    catch_main.cpp
-    test_contract_checking.cpp
-)
-target_link_libraries(test_contract_checking PUBLIC span)
+add_executable(test_span_contract_checking
+               test_contract_checking.cpp)
+target_link_libraries(test_span_contract_checking PUBLIC span catch_main)
+set_target_properties(test_span_contract_checking PROPERTIES
+    CXX_STANDARD ${TCB_SPAN_TEST_CXX_STD})


### PR DESCRIPTION
Rather than (attempting to) build multiple test execuables in the same CMake project using different C++ standard flags, we'll instead keep things simple and have one set of tests per CMake config.

By default, we now only run the compiler in C++11 mode and only test C++11 features. To test in higher modes, use -DTCB_SPAN_TEST_CXX_STD=14 or 17 when configuring CMake.

This PR also enables testing via CTest, and so obsoletes #5  