### PR TITLE
Fix hard error with libstdc++ vector<bool>

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -261,7 +261,11 @@ struct is_container_element_type_compatible : std::false_type {};
 
 template <typename T, typename E>
 struct is_container_element_type_compatible<
-    T, E, void_t<decltype(detail::data(std::declval<T>()))>>
+    T, E,
+    typename std::enable_if<
+        !std::is_same<typename std::remove_cv<decltype(
+                          detail::data(std::declval<T>()))>::type,
+                      void>::value>::type>
     : std::is_convertible<
           remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
           E (*)[]> {};

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -344,6 +344,13 @@ TEST_CASE("Construction from other containers")
     static_assert(
         !std::is_constructible<span<const int, 3>, const deque_t&>::value, "");
 
+    // vector<bool> is not contiguous and cannot be converted to span<bool>
+    // Regression test for https://github.com/tcbrindle/span/issues/24
+    static_assert(
+        !std::is_constructible<span<bool>, std::vector<bool>&>::value, "");
+    static_assert(!std::is_constructible<span<const bool>,
+                                         const std::vector<bool>&>::value, "");
+
     SECTION("non-const, dynamic size")
     {
         vec_t arr = {1, 2, 3};


### PR DESCRIPTION
For some reason, libstdc++'s vector<bool> specialisation has a data() member, even though it's not supposed to. Because this returns void, it tripped up our constructor contraints and caused a hard error by attempting to form an array of void.

The fix is to proceed with the convertibility check only if data() does not return cv void.

Fixes #24