### PR TITLE
Some minor C++20 conformance changes

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -499,10 +499,6 @@ public:
         return reverse_iterator(begin());
     }
 
-    friend constexpr iterator begin(span s) noexcept { return s.begin(); }
-
-    friend constexpr iterator end(span s) noexcept { return s.end(); }
-
 private:
     storage_type storage_{};
 };

--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -302,9 +302,7 @@ public:
     using const_pointer = const element_type*;
     using reference = element_type&;
     using iterator = pointer;
-    using const_iterator = const_pointer;
     using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     static constexpr size_type extent = Extent;
 
@@ -490,10 +488,6 @@ public:
 
     constexpr iterator end() const noexcept { return data() + size(); }
 
-    constexpr const_iterator cbegin() const noexcept { return begin(); }
-
-    constexpr const_iterator cend() const noexcept { return end(); }
-
     TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
     {
         return reverse_iterator(end());
@@ -502,16 +496,6 @@ public:
     TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
     {
         return reverse_iterator(begin());
-    }
-
-    TCB_SPAN_ARRAY_CONSTEXPR const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator(cend());
-    }
-
-    TCB_SPAN_ARRAY_CONSTEXPR const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator(cbegin());
     }
 
     friend constexpr iterator begin(span s) noexcept { return s.begin(); }

--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -301,6 +301,7 @@ public:
     using pointer = element_type*;
     using const_pointer = const element_type*;
     using reference = element_type&;
+    using const_reference = const element_type&;
     using iterator = pointer;
     using reverse_iterator = std::reverse_iterator<iterator>;
 

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -611,30 +611,6 @@ TEST_CASE("span iterator support")
     }
 }
 
-TEST_CASE("span non-member begin/end")
-{
-    {
-        std::vector<int> vec;
-        span<int> s(vec);
-        std::sort(begin(s), end(s));
-        REQUIRE(std::is_sorted(vec.begin(), vec.end()));
-    }
-
-    {
-        const std::vector<int> vec{1, 2, 3};
-        span<const int> s{vec};
-        REQUIRE(std::equal(begin(s), end(s), vec.begin()));
-    }
-
-#ifdef TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
-    {
-        constexpr std::array<int, 3> arr{1, 2, 3};
-        static_assert(*begin(span<const int>{arr}) == 1);
-        static_assert(*(end(span<const int>{arr}) - 1) == 3);
-    }
-#endif
-}
-
 TEST_CASE("make_span()")
 {
     {


### PR DESCRIPTION
* Remove cbegin()/cend() etc
* Add const_reference member typedef
* Remove nonmember begin()/end()