### PR TITLE
Disable Wmisatched-tags for clang compiler in std::tuple helpers specialization

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -590,6 +590,10 @@ constexpr auto get(span<E, S> s) -> decltype(s[N])
 
 namespace std {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
 template <typename ElementType, size_t Extent>
 class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
     : public integral_constant<size_t, Extent> {};
@@ -606,6 +610,9 @@ public:
                   "");
     using type = ElementType;
 };
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 } // end namespace std
 


### PR DESCRIPTION
Fix for #10 as https://github.com/tcbrindle/span/pull/11 didn't seem to be accepted due to some merge conflicts.