### PR TITLE
Update span constructor constraints

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -385,7 +385,8 @@ public:
 
     template <typename OtherElementType, std::size_t OtherExtent,
               typename std::enable_if<
-                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                  (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
+                   Extent == OtherExtent) &&
                       std::is_convertible<OtherElementType (*)[],
                                           ElementType (*)[]>::value,
                   int>::type = 0>

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -407,7 +407,8 @@ TEST_CASE("construction from spans of different size")
                   "");
     static_assert(!std::is_constructible<zero_span, big_span>::value, "");
     static_assert(!std::is_constructible<zero_span, big_const_span>::value, "");
-    static_assert(!std::is_constructible<zero_span, dynamic_span>::value, "");
+    static_assert(std::is_nothrow_constructible<zero_span, dynamic_span>::value,
+                  "");
     static_assert(!std::is_constructible<zero_span, dynamic_const_span>::value,
                   "");
 
@@ -419,17 +420,20 @@ TEST_CASE("construction from spans of different size")
     static_assert(!std::is_constructible<zero_const_span, big_span>::value, "");
     static_assert(
         !std::is_constructible<zero_const_span, big_const_span>::value, "");
-    static_assert(!std::is_constructible<zero_const_span, dynamic_span>::value,
-                  "");
     static_assert(
-        !std::is_constructible<zero_const_span, dynamic_const_span>::value, "");
+        std::is_nothrow_constructible<zero_const_span, dynamic_span>::value,
+        "");
+    static_assert(std::is_nothrow_constructible<zero_const_span,
+                                                dynamic_const_span>::value,
+                  "");
 
     static_assert(!std::is_constructible<big_span, zero_span>::value, "");
     static_assert(!std::is_constructible<big_span, zero_const_span>::value, "");
     static_assert(std::is_trivially_copyable<big_span>::value, "");
     static_assert(std::is_trivially_move_constructible<big_span>::value, "");
     static_assert(!std::is_constructible<big_span, big_const_span>::value, "");
-    static_assert(!std::is_constructible<big_span, dynamic_span>::value, "");
+    static_assert(std::is_nothrow_constructible<big_span, dynamic_span>::value,
+                  "");
     static_assert(!std::is_constructible<big_span, dynamic_const_span>::value,
                   "");
 
@@ -441,10 +445,11 @@ TEST_CASE("construction from spans of different size")
                   "");
     static_assert(
         std::is_nothrow_constructible<big_const_span, big_span>::value, "");
-    static_assert(!std::is_constructible<big_const_span, dynamic_span>::value,
-                  "");
     static_assert(
-        !std::is_constructible<big_const_span, dynamic_const_span>::value, "");
+        std::is_nothrow_constructible<big_const_span, dynamic_span>::value, "");
+    static_assert(std::is_nothrow_constructible<big_const_span,
+                                                dynamic_const_span>::value,
+                  "");
 
     static_assert(std::is_nothrow_constructible<dynamic_span, zero_span>::value,
                   "");


### PR DESCRIPTION
It looks like the constraints for the span constructor taking another span were changed in the standard at some point and this implementation was not updated.

Here is an example showing that this patch fixes #49, based on the example provided in the bug report.
https://godbolt.org/z/bqrMGf6Eb