### PR TITLE
Fix build without exceptions on MSVC

### DIFF
--- a/include/tcb/span.hpp
+++ b/include/tcb/span.hpp
@@ -27,6 +27,8 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 #ifndef TCB_SPAN_NO_EXCEPTIONS
 #include <cstdio>
 #include <stdexcept>
+#else
+#include <exception> // for std::terminate
 #endif
 
 // Various feature test macros


### PR DESCRIPTION
std::terminate is declared in <exception>, so we need to include this header - somewhat ironically - in the non-exception case.